### PR TITLE
Added the @batua after the address per design

### DIFF
--- a/src/components/Account.tsx
+++ b/src/components/Account.tsx
@@ -56,7 +56,7 @@ export const Account = (props: { address: string }) => {
         </Typography>
         <Paper className={classes.paper}>
           <CardHeader subheader={"WALLET ADDRESS"} /> 
-          <Typography variant="caption" gutterBottom={true}> {address} </Typography>
+          <Typography variant="caption" gutterBottom={true}> {address}@batua </Typography>
           <QRCode
             value={`ethereum:${address}`}
             className={classes.qrcode}


### PR DESCRIPTION
Design shows `@batua` after the address:

![image](https://user-images.githubusercontent.com/2212651/96695376-34b9f380-13a7-11eb-8a01-e4f757967e9a.png)

If this is fine @shivgupt please just merge, or lmk what you think